### PR TITLE
Define enum menus for interpolation and window shape attributes

### DIFF
--- a/source/primefir_tilde.cpp
+++ b/source/primefir_tilde.cpp
@@ -169,10 +169,22 @@ extern "C" int C74_EXPORT main(void)
   CLASS_ATTR_LONG(c,    "interp",    0, t_primefir, param_interp);
   CLASS_ATTR_ACCESSORS(c, "interp", NULL, primefir_attr_set_interp);
   CLASS_ATTR_STYLE_LABEL(c, "interp", 0, "enumindex", "Interpolation (off/linear/lagrange4/catmullrom/farrow3/farrow5)");
+#ifdef CLASS_ATTR_ENUMINDEX
+  CLASS_ATTR_ENUMINDEX(c, "interp", 0,
+                       "off", "linear", "lagrange4", "catmullrom", "farrow3", "farrow5");
+#else
+  CLASS_ATTR_ENUM(c, "interp", 0, "off linear lagrange4 catmullrom farrow3 farrow5");
+#endif
 
   CLASS_ATTR_LONG(c,    "winshape",  0, t_primefir, param_winshape);
   CLASS_ATTR_ACCESSORS(c, "winshape", NULL, primefir_attr_set_winshape);
   CLASS_ATTR_STYLE_LABEL(c, "winshape", 0, "enumindex", "Window (hann/hamming/blackman/blackmanharris/nuttall/kaiser)");
+#ifdef CLASS_ATTR_ENUMINDEX
+  CLASS_ATTR_ENUMINDEX(c, "winshape", 0,
+                       "hann", "hamming", "blackman", "blackmanharris", "nuttall", "kaiser");
+#else
+  CLASS_ATTR_ENUM(c, "winshape", 0, "hann hamming blackman blackmanharris nuttall kaiser");
+#endif
 
   CLASS_ATTR_DOUBLE(c,  "kaiser_beta", 0, t_primefir, param_kaiser_beta);
   CLASS_ATTR_ACCESSORS(c, "kaiser_beta", NULL, primefir_attr_set_kaiser_beta);


### PR DESCRIPTION
## Summary
- add menu definitions for the interp and winshape attributes so their options populate attribute popups
- support both CLASS_ATTR_ENUMINDEX and CLASS_ATTR_ENUM for SDK compatibility

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5e3b81cb4832ab92551a7f681423e