### PR TITLE
Fix CLASS_ATTR_ENUMINDEX usage

### DIFF
--- a/source/primefir_tilde.cpp
+++ b/source/primefir_tilde.cpp
@@ -173,7 +173,7 @@ extern "C" int C74_EXPORT main(void)
   CLASS_ATTR_STYLE_LABEL(c, "interp", 0, "enumindex", "Interpolation (off/linear/lagrange4/catmullrom/farrow3/farrow5)");
 #ifdef CLASS_ATTR_ENUMINDEX
   CLASS_ATTR_ENUMINDEX(c, "interp", 0,
-                       "off", "linear", "lagrange4", "catmullrom", "farrow3", "farrow5");
+                       "off linear lagrange4 catmullrom farrow3 farrow5");
 #else
   CLASS_ATTR_ENUM(c, "interp", 0, "off linear lagrange4 catmullrom farrow3 farrow5");
 #endif
@@ -183,7 +183,7 @@ extern "C" int C74_EXPORT main(void)
   CLASS_ATTR_STYLE_LABEL(c, "winshape", 0, "enumindex", "Window (hann/hamming/blackman/blackmanharris/nuttall/kaiser)");
 #ifdef CLASS_ATTR_ENUMINDEX
   CLASS_ATTR_ENUMINDEX(c, "winshape", 0,
-                       "hann", "hamming", "blackman", "blackmanharris", "nuttall", "kaiser");
+                       "hann hamming blackman blackmanharris nuttall kaiser");
 #else
   CLASS_ATTR_ENUM(c, "winshape", 0, "hann hamming blackman blackmanharris nuttall kaiser");
 #endif


### PR DESCRIPTION
## Summary
- adjust CLASS_ATTR_ENUMINDEX definitions to pass a single space-separated list of enum labels

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5e5c91300832a8d8feec6694cba1a