### PR TITLE
Add forward declaration for keys_h

### DIFF
--- a/source/primefir_tilde.cpp
+++ b/source/primefir_tilde.cpp
@@ -138,6 +138,8 @@ void        primefir_make_primes(t_primefir* x, int count_needed);
 static int  prime_upper_bound_from_count(int count_needed);
 void        primefir_update_kernel(t_primefir* x);
 
+static inline double keys_h(double a, double x);
+
 // Bessel I0 (Kaiser)
 static inline double i0_approx(double x) {
   double ax = std::abs(x);


### PR DESCRIPTION
## Summary
- add a forward declaration for the Keys cubic helper to ensure it is visible when used in interpolation setup

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e7546f0894832a9dbac9a4936b302e