### PR TITLE
Adjust default window and interpolation defaults

### DIFF
--- a/source/primefir_tilde.cpp
+++ b/source/primefir_tilde.cpp
@@ -264,13 +264,13 @@ void* primefir_new(t_symbol* s, long argc, t_atom* argv)
 
   x->sr              = sys_getsr(); if (x->sr <= 0) x->sr = 44100.0;
   x->param_freq      = 1.0;
-  x->param_window    = 1.0;
+  x->param_window    = 0.25;                         // compromesso: ~257 tap @44.1k, buon bilancio qualità/CPU
   x->param_mode      = (long)seq_mode::prime;
   x->param_normalize = 0;
   x->param_gaincomp  = 1;
   x->param_linphase  = 0;
 
-  x->param_interp    = (long)interp_mode::farrow5;    // default: massima qualità
+  x->param_interp    = (long)interp_mode::linear;      // default: più leggero, buona trasparenza
   x->param_winshape  = (long)winshape::blackmanharris;// default: BH 4-term
   x->param_kaiser_beta = 9.5;
   x->param_keys_a    = -0.5;


### PR DESCRIPTION
## Summary
- lower the default window parameter to target roughly 257 taps at 44.1 kHz for a better CPU/quality balance
- switch the default interpolation mode to the lighter linear interpolator while keeping transparency

## Testing
- cmake -S . -B build *(fails: missing Max SDK cmake includes in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e8213a1c10832a8bdd5d994e9445b4