### PR TITLE
Add user feedback for inactive kaiser_beta and keys_a settings

### DIFF
--- a/source/primefir_tilde.cpp
+++ b/source/primefir_tilde.cpp
@@ -398,11 +398,25 @@ t_max_err primefir_attr_set_winshape(t_primefir* x, void*, long ac, t_atom* av) 
   return MAX_ERR_NONE;
 }
 t_max_err primefir_attr_set_kaiser_beta(t_primefir* x, void*, long ac, t_atom* av) {
-  if (ac && av) { x->param_kaiser_beta = atom_getfloat(av); x->dirty = true; }
+  if (ac && av) {
+    x->param_kaiser_beta = atom_getfloat(av);
+    x->dirty = true;
+    if (static_cast<winshape>(x->param_winshape) != winshape::kaiser) {
+      object_post(reinterpret_cast<t_object*>(x),
+                  "primefir~: @kaiser_beta è attivo solo con @winshape kaiser");
+    }
+  }
   return MAX_ERR_NONE;
 }
 t_max_err primefir_attr_set_keys_a(t_primefir* x, void*, long ac, t_atom* av) {
-  if (ac && av) { x->param_keys_a = atom_getfloat(av); x->dirty = true; }
+  if (ac && av) {
+    x->param_keys_a = atom_getfloat(av);
+    x->dirty = true;
+    if (static_cast<interp_mode>(x->param_interp) != interp_mode::catmullrom) {
+      object_post(reinterpret_cast<t_object*>(x),
+                  "primefir~: @keys_a controlla solo l'interpolazione catmullrom");
+    }
+  }
   return MAX_ERR_NONE;
 }
 


### PR DESCRIPTION
## Summary
- post console notices when kaiser_beta is adjusted without the Kaiser window selected
- inform users that keys_a only affects Catmull-Rom interpolation

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e8af30c9d4832a8c0039d90c00d484