### PR TITLE
Exclude backup sources from build inputs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,9 @@ file(GLOB SRC
   "${CMAKE_CURRENT_LIST_DIR}/source/*.cxx"
 )
 
+# Skip any backup sources so they don't get compiled alongside the real one.
+list(FILTER SRC EXCLUDE REGEX "_backup")
+
 # Target SENZA tilde; bundle CON tilde
 add_library(primefir MODULE ${SRC})
 set_target_properties(primefir PROPERTIES


### PR DESCRIPTION
## Summary
- exclude backup source files from the globbed source list to prevent duplicate symbol errors during linking

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e8e87a5508832ab0272fbfec553628